### PR TITLE
Config generates SQS ingestion if enabled

### DIFF
--- a/infra/lib/log-source.ts
+++ b/infra/lib/log-source.ts
@@ -72,7 +72,6 @@ export interface LogSourceConfig {
     expand_records_from_payload?: string;
     compression: string;
     s3_source?: {
-      enabled?: boolean,
       bucket_name?: string;
       key_prefix?: string;
     };

--- a/infra/lib/log-source.ts
+++ b/infra/lib/log-source.ts
@@ -72,9 +72,13 @@ export interface LogSourceConfig {
     expand_records_from_payload?: string;
     compression: string;
     s3_source?: {
+      enabled?: boolean,
       bucket_name?: string;
       key_prefix?: string;
     };
+    sqs_source?: {
+      enabled?: boolean
+    }
   };
   transform?: string;
   managed?: {
@@ -296,6 +300,7 @@ export class MatanoLogSource extends Construct {
       ingest: {
         compression: this.logSourceConfig.ingest?.compression,
         s3_source: this.logSourceConfig?.ingest?.s3_source,
+        sqs_source: this.logSourceConfig?.ingest?.sqs_source,
         select_table_from_payload_metadata: this.logSourceConfig.ingest?.select_table_from_payload_metadata,
       },
       managed: this.logSourceConfig.managed,

--- a/infra/lib/sqs-sources.ts
+++ b/infra/lib/sqs-sources.ts
@@ -7,7 +7,7 @@ interface MatanoSQSSourcesProps {
 }
 
 export class MatanoSQSSources extends Construct {
-  outputQueues: sqs.Queue[] = [];
+  ingestionQueues: sqs.Queue[] = [];
   constructor(scope: Construct, id: string, props: MatanoSQSSourcesProps) {
     super(scope, id);
 
@@ -15,12 +15,12 @@ export class MatanoSQSSources extends Construct {
       const name = logSource.name.split("_")
         .map((substr) => substr.charAt(0).toUpperCase() + substr.slice(1));
 
-      const outputDLQ = new sqs.Queue(this, `${name}OutputDLQ`);
-      const outputQueue = new sqs.Queue(this, `${name}OutputQueue`, {
-        deadLetterQueue: { queue: outputDLQ, maxReceiveCount: 3 },
+      const ingestionDLQ = new sqs.Queue(this, `${name}IngestionDLQ`);
+      const ingestionQueue = new sqs.Queue(this, `${name}IngestionQueue`, {
+        deadLetterQueue: { queue: ingestionDLQ, maxReceiveCount: 3 },
       });
 
-      this.outputQueues.push(outputQueue);
+      this.ingestionQueues.push(ingestionQueue);
     }
   }
 }

--- a/infra/lib/sqs-sources.ts
+++ b/infra/lib/sqs-sources.ts
@@ -1,0 +1,26 @@
+import { Construct } from "constructs";
+import * as sqs from "aws-cdk-lib/aws-sqs";
+import { MatanoLogSource } from "./log-source";
+
+interface MatanoSQSSourcesProps {
+  logSources: MatanoLogSource[];
+}
+
+export class MatanoSQSSources extends Construct {
+  outputQueues: sqs.Queue[] = [];
+  constructor(scope: Construct, id: string, props: MatanoSQSSourcesProps) {
+    super(scope, id);
+
+    for (const logSource of props.logSources) {
+      const name = logSource.name.split("_")
+        .map((substr) => substr.charAt(0).toUpperCase() + substr.slice(1));
+
+      const outputDLQ = new sqs.Queue(this, `${name}OutputDLQ`);
+      const outputQueue = new sqs.Queue(this, `${name}OutputQueue`, {
+        deadLetterQueue: { queue: outputDLQ, maxReceiveCount: 3 },
+      });
+
+      this.outputQueues.push(outputQueue);
+    }
+  }
+}

--- a/infra/src/DPCommonStack.ts
+++ b/infra/src/DPCommonStack.ts
@@ -51,7 +51,9 @@ export class DPCommonStack extends MatanoStack {
       catalogId: cdk.Aws.ACCOUNT_ID,
     });
 
-    const matanoAthenaResultsBucket = new s3.Bucket(this, "MatanoAthenaResults");
+    const matanoAthenaResultsBucket = new s3.Bucket(this, "MatanoAthenaResults", {
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+    });
     const matanoAthenaWorkgroup = new athena.CfnWorkGroup(this, "MatanoAthenaWorkGroup", {
       name: "matano",
       description: "[Matano] Matano Athena Work Group.",

--- a/infra/src/DPMainStack.ts
+++ b/infra/src/DPMainStack.ts
@@ -180,9 +180,10 @@ export class DPMainStack extends MatanoStack {
       })
     );
     
-    for (const sqsQueue of sqsSources.outputQueues) {
+    for (const sqsIngestionQueue of sqsSources.ingestionQueues) {
       transformer.transformerLambda.addEventSource(
-        new SqsEventSource(sqsQueue, {
+        new SqsEventSource(sqsIngestionQueue, {
+          enabled: false,
           batchSize: 10000,
           maxBatchingWindow: cdk.Duration.seconds(1),
         })

--- a/infra/src/DPMainStack.ts
+++ b/infra/src/DPMainStack.ts
@@ -25,7 +25,6 @@ import {
 import { S3BucketWithNotifications } from "../lib/s3-bucket-notifs";
 import { MatanoLogSource, LogSourceConfig } from "../lib/log-source";
 import { MatanoDetections } from "../lib/detections";
-import { DockerImage } from "aws-cdk-lib";
 import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { execSync } from "child_process";
 import { SecurityGroup, SubnetType } from "aws-cdk-lib/aws-ec2";
@@ -40,6 +39,7 @@ import { SqsSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
 import { MatanoAlerting } from "../lib/alerting";
 import { MatanoS3Sources } from "../lib/s3-sources";
 import { IcebergMaintenance } from "../lib/iceberg-maintenance";
+import { MatanoSQSSources } from "../lib/sqs-sources";
 
 interface DPMainStackProps extends MatanoStackProps {
   matanoSourcesBucket: S3BucketWithNotifications;
@@ -137,6 +137,10 @@ export class DPMainStack extends MatanoStack {
       sourcesIngestionTopic: props.matanoSourcesBucket.topic,
     });
 
+    const sqsSources = new MatanoSQSSources(this, "SQSIngestionLogSources", {
+      logSources: logSources.filter((ls) => ls.name !== "matano_alerts" && ls.logSourceConfig?.ingest?.sqs_source?.enabled === true),
+    });
+
     const allResolvedSchemasHashStr = logSources
       .flatMap((ls) => Object.values(ls.tablesSchemas))
       .reduce((prev, cur) => prev + JSON.stringify(cur), "");
@@ -175,6 +179,15 @@ export class DPMainStack extends MatanoStack {
         batchSize: 1,
       })
     );
+    
+    for (const sqsQueue of sqsSources.outputQueues) {
+      transformer.transformerLambda.addEventSource(
+        new SqsEventSource(sqsQueue, {
+          batchSize: 10000,
+          maxBatchingWindow: cdk.Duration.seconds(1),
+        })
+      );
+    }
 
     const icebergMetadata = new IcebergMetadata(this, "IcebergMetadata", {
       lakeStorageBucket: props.lakeStorageBucket,


### PR DESCRIPTION
A few thoughts so far:

- **Current impl does not check for both log sources being enabled at once**
    - In a way it's a feature because it allows for multiple ingestion types for a log source (not sure why someone would do that, but it'd be possible)
    - Downside is duplicate data occurs if the same logs get sent to multiple ingestion types
- **In infra/lib/DPMainStack.ts, I think iterating over logSources outside of the S3/SQS Constructs (line 136 & 141) so that both log sources share the same loop would be better**
    - This also sets the stage for adding in more ingestion ingestion types (Kafka, ddb/kinesis streams, SNS)
- **Have not completed an E2E test for SQS ingestion yet (or any necessary impl)**
- **I added "enabled" to s3_source, but this would be a breaking change, so for now S3 is default if nothing is specified**


Also - was caught up on trying to see if managed Matano S3 bucket is working - I don't see /data/<log_source> getting generated when not defining a custom bucket.. is that expected?