### PR TITLE
fix: sqs-ingestion: pass SQS ingestion metadata to Transformer lambda

### DIFF
--- a/infra/lib/sqs-sources.ts
+++ b/infra/lib/sqs-sources.ts
@@ -4,23 +4,40 @@ import { MatanoLogSource } from "./log-source";
 
 interface MatanoSQSSourcesProps {
   logSources: MatanoLogSource[];
+  resolvedLogSourceConfigs: Record<string, any>;
 }
 
 export class MatanoSQSSources extends Construct {
   ingestionQueues: sqs.Queue[] = [];
+  sqsMetadata: string;
+
   constructor(scope: Construct, id: string, props: MatanoSQSSourcesProps) {
     super(scope, id);
 
-    for (const logSource of props.logSources) {
-      const name = logSource.name.split("_")
-        .map((substr) => substr.charAt(0).toUpperCase() + substr.slice(1));
+    const logSources = props.logSources;
+    const resolvedLogSourceConfigs = props.resolvedLogSourceConfigs;
+    let sqsMetadata: Map<string, string[]> = new Map<string, string[]>();
 
-      const ingestionDLQ = new sqs.Queue(this, `${name}IngestionDLQ`);
-      const ingestionQueue = new sqs.Queue(this, `${name}IngestionQueue`, {
-        deadLetterQueue: { queue: ingestionDLQ, maxReceiveCount: 3 },
-      });
+    for (const ls of logSources) {
+      for (const table in resolvedLogSourceConfigs[ls.name].tables) {
 
-      this.ingestionQueues.push(ingestionQueue);
+        const lsName = ls.name.split("_")
+          .map((substr) => substr.charAt(0).toUpperCase() + substr.slice(1));
+
+        const tableName = table.charAt(0).toUpperCase() + table.slice(1);
+
+        const ingestionDLQ = new sqs.Queue(this, `${lsName}${tableName}IngestDLQ`);
+        const ingestionQueue = new sqs.Queue(this, `${lsName}${tableName}IngestQueue`, {
+          deadLetterQueue: { queue: ingestionDLQ, maxReceiveCount: 3 },
+        });
+
+        this.ingestionQueues.push(ingestionQueue);
+        sqsMetadata.set(ingestionQueue.queueName, [ls.name, table]);
+      }
     }
+
+    const obj = Object.fromEntries(sqsMetadata);
+    this.sqsMetadata = JSON.stringify(obj);
+    
   }
 }

--- a/infra/lib/transformer.ts
+++ b/infra/lib/transformer.ts
@@ -12,6 +12,7 @@ interface TransformerProps {
   matanoSourcesBucketName: string;
   logSourcesConfigurationPath: string;
   schemasLayer: lambda.LayerVersion;
+  sqsMetadata: string;
 }
 
 export class Transformer extends Construct {
@@ -37,6 +38,7 @@ export class Transformer extends Construct {
         MATANO_SOURCES_BUCKET: props.matanoSourcesBucketName,
         MATANO_REALTIME_BUCKET_NAME: props.realtimeBucketName,
         MATANO_REALTIME_TOPIC_ARN: props.realtimeTopic.topicArn,
+        SQS_METADATA: props.sqsMetadata,
       },
       layers: [this.rustFunctionLayer.layer, props.schemasLayer],
       timeout: cdk.Duration.seconds(30),


### PR DESCRIPTION
Tweaks to the SQS ingestion cdk, now passing metadata of SQS sources to the Transformer lambda's env vars to distinguish between S3 and SQS. Cleaned up commits too