### PR TITLE
enhancement: CSV file ingest support

### DIFF
--- a/lib/rust/.gitignore
+++ b/lib/rust/.gitignore
@@ -8,3 +8,4 @@ log_sources_configuration.*
 **/*/test.json
 transformer/src/enrichment
 transformer/config
+.idea

--- a/lib/rust/Cargo.lock
+++ b/lib/rust/Cargo.lock
@@ -1523,6 +1523,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv-async"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c19b33b32fd48f83388821bd8f534b59e1b1ffd5c6c83771d1b23abd3dac2685"
+dependencies = [
+ "bstr",
+ "cfg-if",
+ "csv-core",
+ "futures",
+ "itoa 1.0.1",
+ "ryu",
+ "serde",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "csv-core"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4495,6 +4512,7 @@ dependencies = [
  "aws_lambda_events",
  "chrono",
  "config",
+ "csv-async",
  "dyn-clone",
  "flame",
  "futures",

--- a/lib/rust/transformer/Cargo.toml
+++ b/lib/rust/transformer/Cargo.toml
@@ -41,6 +41,7 @@ futures = "0.3"
 serde = "^1.0.144"
 serde_json = "^1.0.89"
 serde_yaml = "0.9"
+csv-async = { version = "1.2.4", features = ["with_serde", "tokio"] }
 log = "^0.4"
 time = "0.3.7"
 lazy_static = "1.4.0"


### PR DESCRIPTION
The real deal this time, tested with example enrichment data and works with the following sample config:

log_source.yml
```
name: "employee"

schema:
  fields:
    - name: "name"
      type: "string"
    - name: "emp_email"
      type: "string"
   - name: "department"
      type: "string"

transform: |
  .name = del(.json.name)
  .emp_email = del(.json.emp_email)
  .department = del(.json.department)
```

And sample CSV data:
```
name,emp_email,department
Jane Doe,jane@company.com,Executive
Joe Smith,joe@company.com,Finance
```

Converting the CSV to NDJSON/JSONL also works as expected.

Any other thoughts / recommendations?

Considering adding to the docs / adding a CSV example with sample data in the `/examples` section of the code, but want to be sure that it is added in a place that you guys would also align with. Just let me know