### PR TITLE
url decode s3 key before attempting to retrieve object

### DIFF
--- a/lib/rust/Cargo.lock
+++ b/lib/rust/Cargo.lock
@@ -4731,6 +4731,7 @@ dependencies = [
  "tokio-util 0.7.3",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
  "value",
  "vrl",
@@ -4870,9 +4871,9 @@ dependencies = [
 
 [[package]]
 name = "urlencoding"
-version = "2.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "utf8-width"

--- a/lib/rust/transformer/Cargo.toml
+++ b/lib/rust/transformer/Cargo.toml
@@ -60,6 +60,7 @@ aws_lambda_events = "0.7.0"
 walkdir = "2.3.2"
 anyhow = "1.0.53"
 config = { version = "0.13.1", features = ["yaml"] }
+urlencoding = "2.1.2"
 
 tikv-jemallocator = { version = "0.5.0" }
 

--- a/lib/rust/transformer/src/main.rs
+++ b/lib/rust/transformer/src/main.rs
@@ -254,7 +254,7 @@ async fn read_events_s3<'a>(
     Pin<Box<dyn Stream<Item = Result<Value>> + Send>>,
 )> {
     println!("Starting download");
-    let dec_key = decode(&r.key.clone()).unwrap().to_string();
+    let dec_key = decode(&r.key.clone())?.into_owned();
 
     let res = s3
         .get_object()

--- a/lib/rust/transformer/src/main.rs
+++ b/lib/rust/transformer/src/main.rs
@@ -52,6 +52,7 @@ use aws_config::SdkConfig;
 use aws_lambda_events::event::sqs::{SqsEvent, SqsMessage};
 use lambda_runtime::{run, service_fn, Context, Error as LambdaError, LambdaEvent};
 use log::{debug, error, info, log_enabled, warn};
+use urlencoding::decode;
 
 use crate::avro::TryIntoAvro;
 
@@ -253,14 +254,16 @@ async fn read_events_s3<'a>(
     Pin<Box<dyn Stream<Item = Result<Value>> + Send>>,
 )> {
     println!("Starting download");
+    let dec_key = decode(&r.key.clone()).unwrap().to_string();
+
     let res = s3
         .get_object()
         .bucket(r.bucket.clone())
-        .key(r.key.clone())
+        .key(dec_key.clone())
         .send()
         .await
         .map_err(|e| {
-            error!("Error downloading {} from S3: {}", r.key, e);
+            error!("Error downloading {} from S3: {}", dec_key, e);
             e
         });
     let mut obj = res?;
@@ -273,7 +276,7 @@ async fn read_events_s3<'a>(
             &mut reader,
             obj.content_encoding.as_deref(),
             obj.content_type.as_deref(),
-            &r.key,
+            dec_key.as_str(),
         )
         .await
         .unwrap_or(Compression::None),
@@ -398,7 +401,7 @@ async fn read_events_s3<'a>(
             })
         }
         None => {
-            if r.key.ends_with("csv") {
+            if dec_key.as_str().ends_with("csv") {
                 let rdr = AsyncReaderBuilder::new()
                     .has_headers(true)
                     .create_deserializer(reader);


### PR DESCRIPTION
Came across the scenario where I had the key "log_source/date=YYYY-MM-DD/...", but the = was encoded as %3D.
(e.g. okta/date%3D2023-01-17/uuid.json.gz)

Adding this url decoding lib handles all encoded char scenarios except for spaces (+ signs). 

Tested functionality for json files and csv files

Curious to hear your thoughts, thanks!