### PR TITLE
fix: Tweak okta log source to normalize okta.target list of structs

### DIFF
--- a/data/managed/log_sources/okta/tables/system.yml
+++ b/data/managed/log_sources/okta/tables/system.yml
@@ -652,7 +652,19 @@ schema:
           - name: severity
             type: string
           - name: target
-            type: string
+            type:
+              type: list
+              element:
+                type: struct
+                fields:
+                  - name: id
+                    type: string
+                  - name: alternate_id
+                    type: string
+                  - name: type
+                    type: string
+                  - name: display_name
+                    type: string
           - name: transaction
             type:
               type: struct


### PR DESCRIPTION
A side effect of updating the okta.target fields to support a list rather than string lead me to have to remove the log_source, deploy Matano, then add the log source again, and deploy Matano

Any thoughts on tables that may have schema evolutions / versioning in a way similar to dbt?

See [okta.target fields](https://docs.elastic.co/en/integrations/okta) and the [Okta model](https://developer.okta.com/docs/reference/api/system-log/#logevent-object-annotated-example) to confirm