### PR TITLE
Add AWS Config history managed log source

### DIFF
--- a/data/managed/log_sources/aws_config_history/log_source.yml
+++ b/data/managed/log_sources/aws_config_history/log_source.yml
@@ -1,0 +1,158 @@
+name: aws_config_history
+
+ingest:
+  expand_records_from_payload: "parse_json!(.__raw).configurationItems"
+
+schema:
+  ecs_field_names:
+    - cloud.account.id
+    - cloud.account.name
+    - cloud.availability_zone
+    - cloud.provider
+    - cloud.region
+    - cloud.service.name
+    - ecs.version
+    - event.kind
+    - event.category
+    - event.created
+    - event.type
+    - event.hash
+    - tags
+
+  fields:
+    - name: aws
+      type:
+        type: struct
+        fields:
+          - name: config_history
+            type:
+              type: struct
+              fields:
+                - name: version
+                  type: string
+                - name: item
+                  type:
+                    type: struct
+                    fields:
+                      - name: status
+                        type: string
+                      - name: capture_time
+                        type: timestamp
+                      - name: md5_hash
+                        type: string
+                      - name: state_id
+                        type: string
+                - name: arn
+                  type: string
+                - name: resource
+                  type:
+                    type: struct
+                    fields:
+                      - name: type
+                        type: string
+                      - name: id
+                        type: string
+                      - name: name
+                        type: string
+                      - name: created
+                        type: timestamp
+                - name: related_events
+                  type:
+                    type: list
+                    element: string
+                - name: relationship
+                  type:
+                    type: list
+                    element:
+                      type: struct
+                      fields:
+                        - name: name
+                          type: string
+                        - name: resource
+                          type:
+                            type: struct
+                            fields:
+                              - name: name
+                                type: string
+                              - name: type
+                                type: string
+                              - name: id
+                                type: string
+                - name: configuration
+                  type: string
+                - name: supplementary_configuration
+                  type: string
+                - name: tags
+                  type: string
+
+transform: |
+  .ts = now() # TODO see if anything better can use.
+
+  .aws.config_history.version = .json.version
+  .aws.config_history.item.capture_time = to_timestamp(.json.configurationItemCaptureTime) ?? null
+  .aws.config_history.item.md5_hash = .json.configurationItemMD5Hash
+  .aws.config_history.item.state_id = to_string(.json.configurationStateId) ?? null
+  .aws.config_history.item.status = .json.configurationItemStatus
+  .aws.config_history.arn = .json.arn
+  .aws.config_history.resource.type = .json.resourceType
+  .aws.config_history.resource.id = .json.resourceId
+  .aws.config_history.resource.name = .json.resourceName
+  .aws.config_history.resource.created = to_timestamp(.json.resourceCreationTime) ?? null
+  .aws.config_history.related_events = .json.relatedEvents
+
+  .aws.config_history.relationship = map_values(array(.json.relationships) ?? []) -> |v| {
+    ret = {}
+    ret.resource = {}
+    ret.resource.name = v.resourceName
+    ret.resource.type = v.resourceType
+    ret.resource.id = v.resourceId
+    ret.name = strip_whitespace(v.relationshipName) ?? null
+    ret
+  }
+
+  .cloud.provider = "aws"
+  .cloud.region = .json.awsRegion
+  .cloud.account.id = .json.awsAccountId || .json.accountId
+  if .json.availabilityZone != "Not Applicable" && .json.availabilityZone != "Regional" {
+    .cloud.availability_zone = .json.availabilityZone
+  }
+  if is_string(.aws.config_history.resource.type) {
+    # AWS::SQS::Queue -> sqs
+    .cloud.service.name = downcase!(split!(.aws.config_history.resource.type, "::", limit: 3)[1])
+  }
+
+  .aws.config_history.configuration = if is_string(.json.configuration) {
+    .json.configuration
+  } else if !is_empty(object(.json.configuration) ?? {}) {
+    encode_json(.json.configuration)
+  }
+
+  if !is_empty(object(.json.supplementaryConfiguration) ?? {}) {
+    .aws.config_history.supplementary_configuration = encode_json(.json.supplementaryConfiguration)
+  }
+
+  if !is_empty(object(.json.tags) ?? {}) {
+    .aws.config_history.tags = encode_json(.json.tags)
+
+    obj_tags = object!(.json.tags)
+    .tags = []
+    for_each(obj_tags) -> |k, v| {
+      tag = join!([k, v], "=")
+      .tags = push(.tags, tag)
+    }
+  }
+
+  .event.kind = "event"
+  .event.category = ["configuration"]
+  .event.hash = .aws.config_history.item.md5_hash
+
+  if is_string(.aws.config_history.item.status) {
+    status = string!(.aws.config_history.item.status)
+    .event.type = if contains(status, "ResourceDeleted") {
+      ["deletion"]
+    } else if status == "ResourceDiscovered" || status == "ResourceNotRecorded" {
+      ["creation"]
+    } else {
+      ["change"]
+    }
+  }

--- a/data/managed/log_sources/github_audit/log_source.yml
+++ b/data/managed/log_sources/github_audit/log_source.yml
@@ -179,4 +179,8 @@ transform: |2-
     .event.type = push(.event.type, "creation")
   }
 
+  .related.user = unique(.related.user)
+  .event.type = unique(.event.type)
+  .event.category = unique(.event.category)
+
   del(._temp)

--- a/infra/lib/log-source.ts
+++ b/infra/lib/log-source.ts
@@ -99,6 +99,7 @@ const MANAGED_LOG_SOURCE_PREFIX_MAP: Record<string, string> = {
   aws_s3access: "aws",
   aws_elb: "aws",
   aws_inspector: "aws",
+  aws_config_history: "aws",
   crowdstrike: "crowdstrike",
   crowdstrike_falcon: "crowdstrike",
   duo: "duo",


### PR DESCRIPTION
- Tracks AWS Config history data
- Support S3 ingestion

As in #51

### Testing

- All tests passed in https://github.com/matanolabs/logtest/commit/9e20550475bc0154dfbb015f608822e1e458f223

- Manually deployed

<img width="886" alt="Screenshot 2023-01-26 at 3 56 33 PM" src="https://user-images.githubusercontent.com/9027301/214976754-1e79c516-ce44-4357-825b-a79d03a76e95.png">


#### Sample event

```json
{
    "ts": "2023-01-26 23:40:44.868",
    "aws": {
        "config_history": {
            "version": null,
            "item": {
                "status": "ResourceNotRecorded",
                "capture_time": "2023-01-26 06:06:53.998",
                "md5_hash": null,
                "state_id": "1674713213998"
            },
            "arn": null,
            "resource": {
                "type": "AWS::Athena::WorkGroup",
                "id": "athenav3",
                "name": "athenav3",
                "created": "2022-11-10 19:29:05.461"
            },
            "related_events": null,
            "relationship": null,
            "configuration": null,
            "supplementary_configuration": null,
            "tags": null
        }
    },
    "labels": null,
    "tags": null,
    "cloud": {
        "account": {
            "id": "123456789012",
            "name": null
        },
        "availability_zone": null,
        "provider": "aws",
        "region": "eu-west-1",
        "service": {
            "name": "athena"
        }
    },
    "ecs": {
        "version": "8.5.0"
    },
    "event": {
        "kind": "event",
        "category": [
            "configuration"
        ],
        "created": null,
        "type": [
            "creation"
        ],
        "hash": null
    }
}
```