### PR TITLE
Add Google Workspace managed log source w/ Logins as 1st table

### DIFF
--- a/data/managed/log_sources/google_workspace/log_source.yml
+++ b/data/managed/log_sources/google_workspace/log_source.yml
@@ -1,0 +1,5 @@
+name: google_workspace
+
+ingest:
+  select_table_from_payload: |
+    string(del(.json._table)) ?? { abort }

--- a/data/managed/log_sources/google_workspace/tables/login.yml
+++ b/data/managed/log_sources/google_workspace/tables/login.yml
@@ -1,0 +1,227 @@
+name: login
+
+schema:
+  ecs_field_names:
+    - ecs.version
+    - event.action
+    - event.category
+    - event.created
+    - event.id
+    - event.kind
+    - event.outcome
+    - event.provider
+    - event.start
+    - event.type
+    - group.domain
+    - group.id
+    - group.name
+    - message
+    - organization.id
+    - related.hash
+    - related.hosts
+    - related.ip
+    - related.user
+    - source.address
+    - source.as.number
+    - source.as.organization.name
+    - source.ip
+    - source.user.domain
+    - source.user.email
+    - source.user.id
+    - source.user.name
+    - tags
+    - user.domain
+    - user.email
+    - user.id
+    - user.name
+    - user.target.domain
+    - user.target.email
+    - user.target.group.domain
+    - user.target.group.id
+    - user.target.group.name
+    - user.target.id
+    - user.target.name
+  fields:
+    - name: google_workspace
+      type:
+        type: struct
+        fields:
+          - name: actor
+            type:
+              type: struct
+              fields:
+                - name: key
+                  type: string
+                - name: type
+                  type: string
+          - name: event
+            type:
+              type: struct
+              fields:
+                - name: type
+                  type: string
+          - name: kind
+            type: string
+          - name: organization
+            type:
+              type: struct
+              fields:
+                - name: domain
+                  type: string
+          - name: login
+            type:
+              type: struct
+              fields:
+                - name: affected_email_address
+                  type: string
+                - name: challenge_method
+                  type:
+                    type: list
+                    element: string
+                - name: challenge_status
+                  type: string
+                - name: failure_type
+                  type: string
+                - name: is_second_factor
+                  type: boolean
+                - name: is_suspicious
+                  type: boolean
+                - name: timestamp
+                  type: long
+                - name: type
+                  type: string
+
+transform: |-
+  .event.category = ["authentication"]
+  .event.type = []
+  .event.kind = "event"
+
+  if is_array(.json.events) {
+    .json.events = array!(.json.events)[0]
+  }
+
+  .event.action = del(.json.events.name)
+  .event.provider = del(.json.id.applicationName)
+  if .json.id.uniqueQualifier != null {
+      .event.id = to_string!(.json.id.uniqueQualifier)
+  }
+
+  if .json.id.time != null {
+    .ts = to_timestamp!(.json.id.time, "seconds")
+  }
+
+  .source.user.email = del(.json.actor.email)
+
+  .user.email = .source.user.email
+
+  if .json.actor.profileId != null {
+      .source.user.id = to_string!(.json.actor.profileId)
+  }
+
+  if .json.ipAddress != null {
+      .source.ip = to_string!(.json.ipAddress)
+  }
+
+  .google_workspace.kind = del(.json.kind)
+
+  if .json.id.customerId != null {
+      .organization.id = to_string!(.json.id.customerId)
+  }
+
+  .google_workspace.actor.type = del(.json.actor.callerType)
+  .google_workspace.actor.key = del(.json.actor.key)
+  .google_workspace.organization.domain = del(.json.ownerDomain)
+  .google_workspace.event.type = del(.json.events.type)
+
+  if contains(.source.user.email, "@") ?? false {
+    splitmail = split(.source.user.email, "@", limit: 2) ?? []
+  	if (length(splitmail) == 2) {
+      .user.name = splitmail[0]
+      .source.user.name = splitmail[0]
+      .user.domain = splitmail[1]
+      .source.user.domain = splitmail[1]
+    }
+  }
+
+  .user.id = .source.user.id
+
+  if .source.ip != null {
+      .related.ip = push(.related.ip, .source.ip)
+  }
+  if .source.user.name != null {
+      .related.user = push(.related.user, .source.user.name)
+  }
+
+  if includes(["login_failure", "login_success", "logout"], .event.action) {
+      .event.category = push(.event.category, "session")
+  }
+  if includes(["login_failure", "login_success"], .event.action) {
+      .event.type = push(.event.type, "start")
+  }
+  if .event.action == "logout" {
+      .event.type = push(.event.type, "end")
+  }
+  if includes(["account_disabled_generic", "account_disabled_spamming_through_relay", "account_disabled_spamming", "account_disabled_hijacked", "account_disabled_password_leak"], .event.action) {
+      .event.type = push(.event.type, "user")
+  }
+  if includes(["account_disabled_generic", "account_disabled_spamming_through_relay", "account_disabled_spamming", "account_disabled_hijacked", "account_disabled_password_leak"], .event.action) {
+      .event.type = push(.event.type, "change")
+  }
+  if includes(["gov_attack_warning", "login_challenge", "login_verification", "suspicious_login", "suspicious_login_less_secure_app", "suspicious_programmatic_login"], .event.action) {
+      .event.type = push(.event.type, "info")
+  }
+
+
+  if is_array(.json.events.parameters) {
+    params = array!(.json.events.parameters)
+    for_each(params) -> |i, v| {
+      if starts_with(v.name, "login_") ?? false {
+        v.name = slice!(v.name, 6)
+      }
+      if v.value != null {
+        .google_workspace.login = set!(.google_workspace.login, [v.name], v.value)
+      }
+      if v.intValue != null {
+        .google_workspace.login = set!(.google_workspace.login, [v.name], to_int!(v.intValue))
+      }
+      if v.multiValue != null {
+        .google_workspace.login = set!(.google_workspace.login, [v.name], v.multiValue)
+      }
+    }
+  }
+
+  if .google_workspace.login.timestamp != null {
+    .event.start = to_timestamp!(int!(.google_workspace.login.timestamp) * 1000, "nanoseconds")
+  }
+
+
+  if .google_workspace.login.challenge_status != null && .event.outcome == null && .google_workspace.login.challenge_status == "Challenge Passed" {
+    .event.outcome = "success"
+  } else if .google_workspace.login.challenge_status != null && .event.outcome == null {
+    .event.outcome = "failure"
+  }
+
+  if .event.action == "login_failure" {
+    .event.outcome = "failure"
+  } else if .event.action == "login_success" {
+    .event.outcome = "success"
+  }
+
+  if contains(.google_workspace.login.affected_email_address, "@") ?? false {
+    splitmail = split(.google_workspace.login.affected_email_address, "@", limit: 2) ?? []
+  	if (length(splitmail) == 2) {
+      if (.related.user == null) {
+        .related.user = []
+      }
+
+      .user.target.name = splitmail[0]
+  	  .user.target.domain = splitmail[1]
+  	  .related.user = push(.related.user, .user.target.name)
+  	}
+
+  }
+
+  .source.as.number = del(.source.as.asn)
+  .source.as.organization.name = del(.source.as.organization_name)
+
+  .related.user = compact(.related.user)

--- a/infra/lib/log-puller.ts
+++ b/infra/lib/log-puller.ts
@@ -22,6 +22,7 @@ export const PULLER_LOG_SOURCE_TYPES: string[] = [
   "aws_inspector",
   "msft",
   "o365",
+  "google_workspace",
   "duo",
   "okta",
   "snyk",
@@ -31,10 +32,11 @@ export const PULLER_LOG_SOURCE_TYPES: string[] = [
   "enrich_otx",
 ];
 const LOG_SOURCE_RATES: Record<string, cdk.Duration> = {
-  "onepassword": cdk.Duration.minutes(1),
+  onepassword: cdk.Duration.minutes(1),
   aws_inspector: cdk.Duration.minutes(10),
   msft: cdk.Duration.minutes(1),
   o365: cdk.Duration.minutes(1),
+  google_workspace: cdk.Duration.minutes(1),
   duo: cdk.Duration.minutes(1),
   okta: cdk.Duration.minutes(1),
   snyk: cdk.Duration.hours(24),
@@ -89,6 +91,10 @@ export class ExternalLogPuller extends Construct {
       } else if (logSourceName.startsWith("onepassword")) {
         placeholder = {
           api_token: placeholder_val,
+        };
+      } else if (logSourceName.startsWith("google_workspace")) {
+        placeholder = {
+          private_key: placeholder_val,
         };
       } else {
         placeholder = {

--- a/infra/lib/log-source.ts
+++ b/infra/lib/log-source.ts
@@ -100,7 +100,7 @@ interface MatanoLogSourceProps {
 }
 
 const MANAGED_LOG_SOURCE_PREFIX_MAP: Record<string, string> = {
-  "onepassword": "onepassword",
+  onepassword: "onepassword",
   aws_cloudtrail: "aws",
   aws_route53_resolver_logs: "aws",
   aws_s3access: "aws",
@@ -114,6 +114,7 @@ const MANAGED_LOG_SOURCE_PREFIX_MAP: Record<string, string> = {
   duo: "duo",
   msft: "msft",
   o365: "o365",
+  google_workspace: "google_workspace",
   github_audit: "github",
   okta: "okta",
   snyk: "snyk",

--- a/lib/rust/Cargo.lock
+++ b/lib/rust/Cargo.lock
@@ -2494,6 +2494,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f4f04699947111ec1733e71778d763555737579e44b85844cae8e1940a1828"
+dependencies = [
+ "base64 0.13.1",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,6 +2785,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
+ "jsonwebtoken",
  "lambda_runtime",
  "lazy_static 1.4.0",
  "log",
@@ -3305,6 +3320,15 @@ name = "peeking_take_while"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e9ed2178b0575fff8e1b83b58ba6f75e727aafac2e1b6c795169ad3b17eb518"
+
+[[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -4175,6 +4199,18 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time 0.3.13",
+]
 
 [[package]]
 name = "siphasher"

--- a/lib/rust/log_puller/Cargo.toml
+++ b/lib/rust/log_puller/Cargo.toml
@@ -33,6 +33,7 @@ reqwest = { version = "0.11.2", default-features = false, features = [
   "rustls-tls-native-roots",
   "json",
 ] }
+jsonwebtoken = "8.2.0"
 tikv-jemallocator = { version = "0.5.0" }
 chrono = "0.4.19"
 async-trait = "0.1.58"

--- a/lib/rust/log_puller/src/main.rs
+++ b/lib/rust/log_puller/src/main.rs
@@ -204,7 +204,7 @@ async fn handler(event: LambdaEvent<SqsEvent>) -> Result<Option<SQSBatchResponse
         })
         .map(|(msg_id, record)| {
             process_record(msg_id.clone(), record, client.clone(), contexts)
-                .map_err(|e| SQSLambdaError::new(e.to_string(), msg_id))
+                .map_err(|e| SQSLambdaError::new(format!("{:#}", e), msg_id))
         })
         .filter_map(|r| r.map_err(|e| errors.push(e)).ok())
         .collect::<Vec<_>>();
@@ -277,7 +277,7 @@ fn process_record(
     }
     .map_err(move |e| {
         let e = e.context(format!("Error for log_source: {}", log_source_name));
-        SQSLambdaError::new(e.to_string(), msg_id)
+        SQSLambdaError::new(format!("{:#}", e), msg_id)
     });
     Ok(fut)
 }

--- a/lib/rust/log_puller/src/pullers/duo.rs
+++ b/lib/rust/log_puller/src/pullers/duo.rs
@@ -37,8 +37,8 @@ impl PullLogs for DuoPuller {
 
         let config = ctx.config();
         let tables_config = ctx.tables_config();
-        let cache = ctx.cache();
-        let mut cache = cache.lock().await;
+        // let cache = ctx.cache();
+        // let mut cache = cache.lock().await;
 
         let api_hostname = config.get("api_hostname").context("Missing api_hostname")?;
         let integration_key = config

--- a/lib/rust/log_puller/src/pullers/google_workspace.rs
+++ b/lib/rust/log_puller/src/pullers/google_workspace.rs
@@ -1,0 +1,233 @@
+use serde_json::json;
+use std::{borrow::Borrow, collections::HashMap, sync::Arc, time::Instant};
+
+use anyhow::{anyhow, Context as AnyhowContext, Error, Result};
+use async_stream::{stream, try_stream};
+use async_trait::async_trait;
+use chrono::{DateTime, FixedOffset};
+use futures::{future::join_all, Stream};
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use lazy_static::lazy_static;
+use log::{debug, error, info};
+
+use super::{PullLogs, PullLogsContext};
+use shared::JsonValueExt;
+
+#[derive(Clone)]
+pub struct GoogleWorkspacePuller;
+
+struct GoogResourceProps {
+    resource: String,
+    /// Google workspace events can be lagged from minutes to hours to days. See https://support.google.com/a/answer/7061566
+    lag: chrono::Duration,
+}
+
+fn table_resource_map() -> HashMap<String, GoogResourceProps> {
+    [(
+        "login",
+        GoogResourceProps {
+            resource: "login".to_string(),
+            lag: chrono::Duration::hours(2),
+        },
+    )]
+    .into_iter()
+    .map(|(k, v)| (k.to_string(), v))
+    .collect::<HashMap<_, _>>()
+}
+
+lazy_static! {
+    static ref TABLE_RESOURCE_MAP: HashMap<String, GoogResourceProps> = table_resource_map();
+}
+
+#[async_trait]
+impl PullLogs for GoogleWorkspacePuller {
+    async fn pull_logs(
+        self,
+        client: reqwest::Client,
+        ctx: &PullLogsContext,
+        start_dt: DateTime<FixedOffset>,
+        end_dt: DateTime<FixedOffset>,
+    ) -> Result<Vec<u8>> {
+        info!("Pulling Google Workspace logs....");
+
+        let config = ctx.config();
+        let cache = ctx.cache();
+
+        let checkpoint_json = ctx.checkpoint_json.lock().await;
+        let is_initial_run = checkpoint_json.is_none();
+
+        let client_email = config.get("client_email").context("Missing client_email")?;
+        let admin_email = config.get("admin_email").context("Missing admin_email")?;
+        let private_key = ctx
+            .get_secret_field("private_key")
+            .await
+            .map_err(|e| {
+                error!("Error getting private key: {}", e);
+                e
+            })?
+            .context("Missing private key")?;
+
+        // skip early if private_key is equal <placeholder>
+        if private_key == "<placeholder>" {
+            return Ok(vec![]);
+        }
+
+        let access_token = {
+            let mut cache = cache.lock().await;
+            match cache.get("access_token") {
+                Some(token) => token.to_owned(),
+                None => {
+                    let token =
+                        get_access_token(client.clone(), client_email, admin_email, &private_key)
+                            .await?;
+                    cache.set("access_token", token.clone(), None);
+                    token
+                }
+            }
+        };
+
+        let start_dt = if is_initial_run {
+            start_dt - chrono::Duration::days(14)
+        } else {
+            start_dt
+        };
+
+        let end_time = end_dt.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+        let tables = ctx.tables_config.keys().collect::<Vec<_>>();
+        if tables.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let table_resources = tables
+            .into_iter()
+            .filter_map(|t| Some((t, TABLE_RESOURCE_MAP.get(t)?)));
+
+        let futs = table_resources
+            .map(|(table, resource)| {
+                let start_dt = start_dt - resource.lag;
+                let start_time = start_dt.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+                list_resource(
+                    client.clone(),
+                    &resource.resource,
+                    table,
+                    &access_token,
+                    start_time,
+                    &end_time,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let results = join_all(futs)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+
+        Ok(results)
+    }
+}
+
+async fn get_access_token(
+    client: reqwest::Client,
+    client_email: &str,
+    admin_email: &str,
+    private_key: &str,
+) -> Result<String> {
+    let now = chrono::Utc::now().timestamp();
+
+    let claims = json!({
+      "iss": client_email,
+      "scope": "https://www.googleapis.com/auth/admin.reports.audit.readonly",
+      "aud": "https://oauth2.googleapis.com/token",
+      "iat": now,
+      "exp": now + 3600,
+      "sub": admin_email
+    });
+    let key = EncodingKey::from_rsa_pem(private_key.as_bytes())?;
+    let token = encode(&Header::new(Algorithm::RS256), &claims, &key)?;
+
+    let access_token = client
+        .post("https://oauth2.googleapis.com/token")
+        .form(&[
+            ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+            ("assertion", &token),
+        ])
+        .send()
+        .await?
+        .json::<serde_json::Value>()
+        .await?
+        .get_mut("access_token")
+        .and_then(|v| v.take().into_str())
+        .context("Missing access token")?;
+
+    Ok(access_token)
+}
+
+async fn list_resource(
+    client: reqwest::Client,
+    resource: &str,
+    table: &str,
+    access_token: &str,
+    start_time: String,
+    end_time: &str,
+) -> Result<Vec<u8>> {
+    let url = format!(
+        "https://admin.googleapis.com/admin/reports/v1/activity/users/all/applications/{}",
+        resource
+    );
+    let mut first = true;
+    let mut next_token: Option<String> = None;
+
+    let mut ret: Vec<u8> = vec![];
+
+    while first || next_token.is_some() {
+        let mut qs = vec![
+            ("maxResults", "1000"),
+            ("prettyPrint", "false"),
+            ("startTime", &start_time),
+            ("endTime", end_time),
+        ];
+        if let Some(token) = next_token.as_ref() {
+            qs.push(("pageToken", token));
+        }
+        let res = client
+            .get(&url)
+            .bearer_auth(access_token)
+            .query(&qs)
+            .send()
+            .await?;
+
+        let is_failure = !res.status().is_success();
+        if is_failure {
+            let body = res.text().await?;
+            let msg = format!("Error calling url: {}, response: {}", &url, body);
+            return Err(anyhow!(msg));
+        }
+
+        let mut body = res.json::<serde_json::Value>().await?;
+        let items = body
+            .get_mut("items")
+            .and_then(|v| v.take().into_array())
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|v| v.into_object())
+            .peekable();
+
+        for mut item in items {
+            item.insert("_table".to_string(), table.into());
+            ret.extend(serde_json::to_vec(&item)?);
+            ret.push(b'\n');
+        }
+
+        next_token = body
+            .get_mut("nextPageToken")
+            .and_then(|v| v.take().into_str());
+        first = false;
+    }
+
+    Ok(ret)
+}

--- a/lib/rust/log_puller/src/pullers/mod.rs
+++ b/lib/rust/log_puller/src/pullers/mod.rs
@@ -15,6 +15,7 @@ use shared::secrets::load_secret;
 mod abusech;
 mod amazon_inspector;
 mod duo;
+mod google_workspace;
 mod msft;
 mod o365;
 mod okta;
@@ -189,6 +190,7 @@ pub enum LogSource {
     AmazonInspectorPuller(amazon_inspector::AmazonInspectorPuller),
     O365Puller(o365::O365Puller),
     MicrosoftGraphPuller(msft::MicrosoftGraphPuller),
+    GoogleWorkspacePuller(google_workspace::GoogleWorkspacePuller),
     DuoPuller(duo::DuoPuller),
     OktaPuller(okta::OktaPuller),
     OnePasswordPuller(onepassword::OnePasswordPuller),
@@ -214,6 +216,9 @@ impl LogSource {
             "onepassword" => Some(LogSource::OnePasswordPuller(
                 onepassword::OnePasswordPuller {},
             )),
+            "google_workspace" => Some(LogSource::GoogleWorkspacePuller(
+                google_workspace::GoogleWorkspacePuller {},
+            )),
             "otx" => Some(LogSource::Otx(otx::OtxPuller {})),
             "snyk" => Some(LogSource::Snyk(snyk::SnykPuller {})),
             "abusech_urlhaus" => Some(LogSource::AbuseChUrlhausPuller(
@@ -236,6 +241,7 @@ impl LogSource {
             LogSource::O365Puller(_) => "o365",
             LogSource::OnePasswordPuller(_) => "onepassword",
             LogSource::MicrosoftGraphPuller(_) => "msft",
+            LogSource::GoogleWorkspacePuller(_) => "google_workspace",
             LogSource::Otx(_) => "otx",
             LogSource::Snyk(_) => "snyk",
             LogSource::AbuseChUrlhausPuller(_) => "abusech_urlhaus",

--- a/lib/rust/log_puller/src/pullers/okta.rs
+++ b/lib/rust/log_puller/src/pullers/okta.rs
@@ -90,8 +90,8 @@ impl PullLogs for OktaPuller {
 
         let config = ctx.config();
         let tables_config = ctx.tables_config();
-        let cache = ctx.cache();
-        let mut cache = cache.lock().await;
+        // let cache = ctx.cache();
+        // let mut cache = cache.lock().await;
 
         let limit = 1000;
 

--- a/lib/rust/shared/src/sqs_util.rs
+++ b/lib/rust/shared/src/sqs_util.rs
@@ -18,7 +18,7 @@ impl std::error::Error for SQSLambdaError {}
 
 impl std::fmt::Display for SQSLambdaError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "Failure for SQS message ID:{} - {} ", self.id, self.msg)
+        write!(f, "Failure for message ID:{} - {} ", self.id, self.msg)
     }
 }
 


### PR DESCRIPTION
- Implement poller + parsers/schema for Logins

### Testing

#### Logtest
- Tests passed in https://github.com/matanolabs/logtest/commit/ebfdb4ca89d5504830aec47026fbad084b29c9b4

#### Manual

- Manually deployed and tested

<img width="769" alt="Screenshot 2023-02-06 at 11 09 45 PM" src="https://user-images.githubusercontent.com/9027301/217172856-472202ad-05e3-466d-b3d3-0f76a26af4c5.png">


#### Docs
- At https://www.matano.dev/docs/log-sources/managed/google-workspace


closes #79
ref #78

Signed-off-by: 🐼 Samrose Ahmed 🐼 <samroseahmed@gmail.com>