### PR TITLE
Use async NIO to improve iceberg metadata writer concurrency

### DIFF
--- a/infra/lib/iceberg.ts
+++ b/infra/lib/iceberg.ts
@@ -207,7 +207,7 @@ export class IcebergMetadata extends Construct {
     this.metadataWriterFunction = new lambda.Function(this, "WriterFunction", {
       description: "[Matano] This function ingests written input files into an Iceberg table.",
       runtime: lambda.Runtime.JAVA_11,
-      memorySize: 1024,
+      memorySize: 3000,
       handler: "com.matano.iceberg.IcebergMetadataHandler::handleRequest",
       timeout: cdk.Duration.minutes(3),
       environment: {

--- a/lib/java/matano/iceberg_main/build.gradle.kts
+++ b/lib/java/matano/iceberg_main/build.gradle.kts
@@ -41,29 +41,32 @@ dependencies {
     implementation("com.amazonaws:aws-java-sdk-sts:1.11.1026")
     implementation("com.amazonaws:aws-java-sdk-dynamodb:1.11.1026")
     implementation("com.amazonaws:aws-lambda-java-core:1.2.1")
+    implementation("com.amazonaws:aws-lambda-java-events:3.11.0")
 
     implementation("org.apache.hadoop:hadoop-mapreduce-client-core:3.3.3")
     implementation("org.apache.parquet:parquet-hadoop-bundle:1.12.3")
     implementation("org.apache.parquet:parquet-avro:1.12.3")
-    implementation("software.amazon.awssdk:glue:2.17.131") {
+    implementation("software.amazon.awssdk:glue:2.20.1") {
         exclude("software.amazon.awssdk", "apache-client")
         exclude("software.amazon.awssdk", "netty-nio-client")
     }
     implementation("software.amazon.awssdk:athena:2.17.131")
-    implementation("software.amazon.awssdk:s3:2.17.131") {
+    implementation("software.amazon.awssdk:s3:2.20.1") {
         exclude("software.amazon.awssdk", "apache-client")
-//        exclude("software.amazon.awssdk", "netty-nio-client")
     }
-    implementation("software.amazon.awssdk:sts:2.17.131") {
+    implementation("software.amazon.awssdk:dynamodb:2.20.1") {
+        exclude("software.amazon.awssdk", "apache-client")
+    }
+    implementation("software.amazon.awssdk:sts:2.20.1") {
         exclude("software.amazon.awssdk", "apache-client")
         exclude("software.amazon.awssdk", "netty-nio-client")
     }
-    implementation("software.amazon.awssdk:url-connection-client:2.17.131")
-    implementation("com.amazonaws:aws-java-sdk-s3:1.11.213")
-    implementation("com.amazonaws:aws-lambda-java-events:3.11.0")
+    implementation("software.amazon.awssdk:netty-nio-client:2.20.1")
+    implementation("software.amazon.awssdk:url-connection-client:2.20.1")
 
     implementation("com.github.luben:zstd-jni:1.5.+")
     implementation("net.lingala.zip4j:zip4j:2.11.1")
+    testImplementation("com.amazonaws:aws-lambda-java-serialization:1.0.1")
 }
 
 application {

--- a/lib/java/matano/iceberg_main/src/main/kotlin/com/matano/iceberg/ExpireSnapshots.kt
+++ b/lib/java/matano/iceberg_main/src/main/kotlin/com/matano/iceberg/ExpireSnapshots.kt
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory
 import java.io.InputStream
 import java.io.OutputStream
 import java.time.OffsetDateTime
-import java.util.concurrent.Executors
 
 data class ExpireSnapshotsRequest(val time: String, val table_name: String)
 
@@ -34,8 +33,8 @@ class ExpireSnapshots {
         val glueCatalog = GlueCatalog().apply { initialize("glue_catalog", IcebergMetadataWriter.icebergProperties) }
         return CachingCatalog.wrap(glueCatalog)
     }
-    val planExecutorService = Executors.newFixedThreadPool(100)
-    val expireExecutorService = Executors.newFixedThreadPool(100)
+    val planExecutorService = cachedBoundedThreadPool(100)
+    val expireExecutorService = cachedBoundedThreadPool(100)
     val namespace = Namespace.of(IcebergMetadataWriter.MATANO_NAMESPACE)
 
     fun handle(event: ExpireSnapshotsRequest) {

--- a/lib/java/matano/iceberg_main/src/main/kotlin/com/matano/iceberg/IOUtil.kt
+++ b/lib/java/matano/iceberg_main/src/main/kotlin/com/matano/iceberg/IOUtil.kt
@@ -13,6 +13,9 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.OutputStream
+import java.util.concurrent.SynchronousQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
 
 class InMemoryOutputFile : OutputFile {
     private val baos = ByteArrayOutputStream()
@@ -139,4 +142,8 @@ class ParquetIcebergOutputFile(private val file: org.apache.iceberg.io.OutputFil
 
     override fun supportsBlockSize() = false
     override fun defaultBlockSize(): Long = 0
+}
+
+fun cachedBoundedThreadPool(maxThreads: Int): ThreadPoolExecutor {
+    return ThreadPoolExecutor(0, maxThreads, 60L, TimeUnit.SECONDS, SynchronousQueue())
 }

--- a/lib/java/matano/iceberg_main/src/main/kotlin/com/matano/iceberg/IcebergMetadataWriter.kt
+++ b/lib/java/matano/iceberg_main/src/main/kotlin/com/matano/iceberg/IcebergMetadataWriter.kt
@@ -1,16 +1,11 @@
 package com.matano.iceberg
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
-import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
-import com.amazonaws.services.dynamodbv2.model.DeleteItemRequest
-import com.amazonaws.services.dynamodbv2.model.PutItemRequest
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
 import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse
 import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse.BatchItemFailure
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
-import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
 import com.amazonaws.services.s3.event.S3EventNotification
+import com.amazonaws.services.s3.event.S3EventNotification.S3EventNotificationRecord
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -20,11 +15,27 @@ import org.apache.iceberg.catalog.Catalog
 import org.apache.iceberg.catalog.Namespace
 import org.apache.iceberg.catalog.TableIdentifier
 import org.apache.iceberg.parquet.ParquetUtil
+import org.apache.parquet.bytes.BytesUtils
+import org.apache.parquet.format.converter.ParquetMetadataConverter
+import org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER
 import org.slf4j.LoggerFactory
+import software.amazon.awssdk.awscore.defaultsmode.DefaultsMode
+import software.amazon.awssdk.core.async.AsyncResponseTransformer
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
+import software.amazon.awssdk.http.nio.netty.SdkEventLoopGroup
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest
+import software.amazon.awssdk.services.s3.S3AsyncClient
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+import java.time.Duration
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.*
+import java.util.stream.Stream
 
 class LazyConcurrentMap<K, V>(
     private val compute: (K) -> V,
@@ -51,9 +62,15 @@ fun dtToHours(s: String): Int {
     return hours.toInt()
 }
 
+// Note: This function is highly IO bound. It generally only runs with a few files at a time.
+// But we need to be handle a large number of files in parallel in case of redrives, failures, etc.
+// JVM concurrency story is a mess, we use Async NIO with Netty to make concurrent requests to read
+// the parquet file footers (main IO bottleneck). Iceberg commit cannot use asynchronous IO but is
+// table level so not as much of a concern.
+// TODO: Performance isn't optimally tuned (see Netty options) for Lambda environment (low memory/CPU) but performs decently well (~15s for 1000 files).
+// TODO: Perhaps we could avoid most of the IO altogether by including the footer metrics in the SQS event (depends on the size).
 class IcebergMetadataWriter {
     private val logger = LoggerFactory.getLogger(this::class.java)
-
     val icebergCatalog: Catalog by lazy { createIcebergCatalog() }
     val enrichmentMetadataWriter: EnrichmentMetadataWriter = EnrichmentMetadataWriter(loadEnrichmentConfiguration())
 
@@ -75,25 +92,50 @@ class IcebergMetadataWriter {
         val partitionValue = parts[3].substring(8)
         val intPartitionvalue = dtToHours(partitionValue)
         val partitionPath = "ts_hour=$intPartitionvalue"
-        logger.info("Using table: $tableName")
         return Pair(tableName, partitionPath)
     }
 
     fun handle(sqsEvent: SQSEvent): SQSBatchResponse {
         val tableObjs = LazyConcurrentMap<String, TableObj>({ name -> TableObj(name) })
-        val failures = mutableListOf<String>()
+        val failures = mutableSetOf<String>()
+        val processFutures = mutableListOf<CompletableFuture<Unit>>()
 
-        runBlocking {
-            for (record in sqsEvent.records) {
-                launch(Dispatchers.IO) {
-                    try { processRecord(record, tableObjs) } catch (e: Exception) {
-                        logger.error(e.message)
-                        failures.add(record.messageId)
-                    }
+        logger.info("Received ${sqsEvent.records.size} records")
+
+        val s3Records = sqsEvent.records.map { record ->
+            val s3EventRecord = S3EventNotification.parseJson(record.body).records[0]
+            val tableNameAndPartitionPath = parseObjectKey(s3EventRecord.s3.`object`.urlDecodedKey)
+            Triple(record.messageId, s3EventRecord, tableNameAndPartitionPath)
+        }
+
+        var start = System.currentTimeMillis()
+        for ((messageId, record, tableAndPartition) in s3Records) {
+            val (tableName, partitionPath) = tableAndPartition
+            if (tableName == "matano_alerts") {
+                continue
+            }
+
+            val tableObj = tableObjs[tableName]
+            if (tableObj == null) {
+                logger.error("Table $tableName does not exist")
+                failures.add(messageId)
+                continue
+            }
+            tableObj.sqsMessageIds.add(messageId)
+            val fut = processRecord(record, tableObj, partitionPath).handleAsync { _, e ->
+                if (e != null && e.cause !is NoSuchKeyException) {
+                    logger.error(e.message)
+                    failures.add(messageId)
                 }
             }
+            processFutures.add(fut)
         }
-        logger.info("Committing...")
+
+        CompletableFuture.allOf(*processFutures.toTypedArray()).join()
+        logger.info("Processed ${sqsEvent.records.size} records in ${System.currentTimeMillis() - start} ms")
+
+        logger.info("Committing for tables: ${tableObjs.keys}")
+        start = System.currentTimeMillis()
         runBlocking {
             for (tableObj in tableObjs.values) {
                 launch(Dispatchers.IO) {
@@ -111,84 +153,108 @@ class IcebergMetadataWriter {
                 }
             }
         }
-        logger.info("DONE!")
+
+        logger.info("Committed tables in ${System.currentTimeMillis() - start} ms")
+
+        if (failures.isNotEmpty()) {
+            logger.error("Encountered ${failures.size} Failures, cleaning up records...")
+            val cleanupFutures = failures.map { sequencer -> deleteDuplicateMarker(sequencer) }
+            CompletableFuture.allOf(*cleanupFutures.toTypedArray()).join()
+        }
+
         return SQSBatchResponse(failures.map { BatchItemFailure(it) })
     }
 
-    fun readParquetMetrics(s3Path: String, table: Table): Metrics {
-        val inputFile = table.io().newInputFile(s3Path)
-        return ParquetUtil.fileMetrics(inputFile, MetricsConfig.forTable(table))
+    fun readParquetMetrics(s3Bucket: String, s3Key: String, table: Table): CompletableFuture<Metrics> {
+        val start = System.currentTimeMillis()
+        val ret = s3Client.getObject({ r ->
+            r.bucket(s3Bucket).key(s3Key).range("bytes=-8")
+        }, AsyncResponseTransformer.toBytes()).thenComposeAsync { r ->
+            val footerLength = BytesUtils.readIntLittleEndian(r.asInputStream())
+            s3Client.getObject({ r ->
+                r.bucket(s3Bucket).key(s3Key).range("bytes=-${footerLength + 8}")
+            }, AsyncResponseTransformer.toBytes())
+                .thenApplyAsync { r ->
+                    val metadata = parquetMetadataConverter.readParquetMetadata(r.asInputStream(), NO_FILTER, null, false, footerLength)
+                    val ret = ParquetUtil.footerMetrics(metadata, Stream.empty(), MetricsConfig.forTable(table))
+                    logger.debug("Read parquet footer for s3://$s3Bucket/$s3Key in: ${System.currentTimeMillis() - start} ms")
+                    ret
+                }
+        }
+        return ret
     }
 
-    suspend fun processRecord(sqsMessage: SQSMessage, tableObjs: Map<String, TableObj>) {
-        val record = S3EventNotification.parseJson(sqsMessage.body).records[0]
+    fun processRecord(record: S3EventNotificationRecord, tableObj: TableObj, partitionPath: String): CompletableFuture<Unit> {
         val s3Bucket = record.s3.bucket.name
         val s3Object = record.s3.`object`
         val s3ObjectKey = s3Object.urlDecodedKey
         val s3ObjectSize = s3Object.sizeAsLong
         val s3Path = "s3://$s3Bucket/$s3ObjectKey"
-        println(s3Path)
 
-        val (tableName, partitionPath) = parseObjectKey(s3ObjectKey)
+        logger.info("Processing record: $s3ObjectKey ($s3ObjectSize bytes) for table: ${tableObj.table.name()}")
 
-        if (tableName == "matano_alerts") {
-            return
-        }
+        return checkDuplicate(s3Object.sequencer).thenComposeAsync { isDuplicate ->
+            if (isDuplicate) {
+                logger.info("Found duplicate SQS message for key: $s3ObjectKey. Skipping...")
+                return@thenComposeAsync CompletableFuture.completedFuture(Unit)
+            }
 
-        if (checkDuplicate(s3Object.sequencer)) {
-            logger.info("Found duplicate SQS message for key: $s3ObjectKey. Skipping...")
-            return
-        }
-
-        try {
-            val tableObj = tableObjs[tableName] ?: throw RuntimeException("table must exist.")
-            tableObj.sqsMessageIds.add(sqsMessage.messageId)
             val icebergTable = tableObj.table
-
             val isEnrichmentTable = icebergTable.name().split(".").last().startsWith("enrich_")
 
-            val metrics = readParquetMetrics(s3Path, icebergTable)
-            val partition = icebergTable.spec()
-            val dataFile = DataFiles.builder(partition)
-                .apply {
-                    if (partition.isPartitioned) { this.withPartitionPath(partitionPath) }
-                }
-                .withPath(s3Path)
-                .withFileSizeInBytes(s3ObjectSize)
-                .withFormat("PARQUET")
-                .withMetrics(metrics)
-                .build()
+            readParquetMetrics(s3Bucket, s3ObjectKey, icebergTable).thenComposeAsync { metrics ->
+                val partition = icebergTable.spec()
+                val dataFile = DataFiles.builder(partition)
+                    .apply {
+                        if (partition.isPartitioned) { this.withPartitionPath(partitionPath) }
+                    }
+                    .withPath(s3Path)
+                    .withFileSizeInBytes(s3ObjectSize)
+                    .withFormat("PARQUET")
+                    .withMetrics(metrics)
+                    .build()
 
-            if (isEnrichmentTable) {
-                enrichmentMetadataWriter.doMetadataWrite(icebergCatalog, icebergTable, dataFile, { tableObj.getAppendFiles() }, { tableObj.getOverwrite() })
-            } else {
-                tableObj.getAppendFiles().appendFile(dataFile)
+                if (isEnrichmentTable) {
+                    enrichmentMetadataWriter.doMetadataWrite(icebergCatalog, icebergTable, dataFile, { tableObj.getAppendFiles() }, { tableObj.getOverwrite() })
+                } else {
+                    tableObj.getAppendFiles().appendFile(dataFile)
+                    CompletableFuture.completedFuture(Unit)
+                }
             }
-        } catch (e: Exception) {
-            // Need to delete on failure to avoid false duplicate skip.
-            deleteDuplicateMarker(s3Object.sequencer)
-            throw e
         }
     }
 
-    fun checkDuplicate(sequencer: String): Boolean {
+    fun checkDuplicate(sequencer: String): CompletableFuture<Boolean> {
         val expireTime = ((System.currentTimeMillis() / 1000L) + DDB_ITEM_EXPIRE_SECONDS).toString()
         val attrs = mapOf(
-            "sequencer" to AttributeValue(sequencer),
-            "ttl" to AttributeValue().apply { this.setN(expireTime) },
+            "sequencer" to AttributeValue.builder().s(sequencer).build(),
+            "ttl" to AttributeValue.builder().n(expireTime).build(),
         )
-        val req = PutItemRequest(DUPLICATES_DDB_TABLE_NAME, attrs)
-            .apply { this.conditionExpression = "attribute_not_exists(sequencer)" }
+        val req = PutItemRequest.builder()
+            .tableName(DUPLICATES_DDB_TABLE_NAME)
+            .item(attrs)
+            .conditionExpression("attribute_not_exists(sequencer)")
+            .build()
 
-        try { ddb.putItem(req) } catch (e: ConditionalCheckFailedException) {
-            return true
+        return ddb.putItem(req).handle { _, e ->
+            if (e != null) {
+                if (e.cause is ConditionalCheckFailedException) {
+                    true
+                } else {
+                    throw e
+                }
+            } else {
+                false
+            }
         }
-        return false
     }
 
-    private fun deleteDuplicateMarker(sequencer: String) {
-        val req = DeleteItemRequest(DUPLICATES_DDB_TABLE_NAME, mapOf("sequencer" to AttributeValue(sequencer)))
-        ddb.deleteItem(req)
+    private fun deleteDuplicateMarker(sequencer: String): CompletableFuture<Unit> {
+        val req = DeleteItemRequest.builder()
+            .tableName(DUPLICATES_DDB_TABLE_NAME)
+            .key(mapOf("sequencer" to AttributeValue.builder().s(sequencer).build()))
+            .build()
+        return ddb.deleteItem(req).thenApplyAsync { }
     }
 
     companion object {
@@ -205,7 +271,38 @@ class IcebergMetadataWriter {
             "write.metadata.delete-after-commit.enabled" to "true",
             "glue.skip-archive" to "true",
         )
-        private val ddb = AmazonDynamoDBClientBuilder.defaultClient()
+
+        val parquetMetadataConverter = ParquetMetadataConverter()
+
+        val ddb = DynamoDbAsyncClient
+            .builder()
+            .httpClientBuilder(
+                NettyNioAsyncHttpClient.builder()
+                    .maxConcurrency(500)
+                    .maxPendingConnectionAcquires(50000)
+                    .connectionAcquisitionTimeout(Duration.ofSeconds(60))
+                    .eventLoopGroupBuilder(
+                        SdkEventLoopGroup.builder().numberOfThreads(10),
+                    )
+                    .tcpKeepAlive(true),
+            )
+            .defaultsMode(DefaultsMode.IN_REGION)
+            .build()
+
+        val s3Client = S3AsyncClient
+            .builder()
+            .httpClientBuilder(
+                NettyNioAsyncHttpClient.builder()
+                    .maxConcurrency(500)
+                    .maxPendingConnectionAcquires(50000)
+                    .connectionAcquisitionTimeout(Duration.ofSeconds(60))
+                    .eventLoopGroupBuilder(
+                        SdkEventLoopGroup.builder().numberOfThreads(10),
+                    )
+                    .tcpKeepAlive(true),
+            )
+            .defaultsMode(DefaultsMode.IN_REGION)
+            .build()
 
         fun createIcebergCatalog(): Catalog {
             return GlueCatalog().apply { initialize("glue_catalog", icebergProperties) }

--- a/lib/java/matano/iceberg_main/src/main/kotlin/com/matano/iceberg/RewriteManifests.kt
+++ b/lib/java/matano/iceberg_main/src/main/kotlin/com/matano/iceberg/RewriteManifests.kt
@@ -11,7 +11,6 @@ import org.apache.iceberg.catalog.TableIdentifier
 import org.slf4j.LoggerFactory
 import java.io.InputStream
 import java.io.OutputStream
-import java.util.concurrent.Executors
 
 data class RewriteManifestsRequest(val table_name: String)
 
@@ -32,7 +31,7 @@ class RewriteManifests {
         val glueCatalog = GlueCatalog().apply { initialize("glue_catalog", IcebergMetadataWriter.icebergProperties) }
         return CachingCatalog.wrap(glueCatalog)
     }
-    val planExecutorService = Executors.newFixedThreadPool(30)
+    val planExecutorService = cachedBoundedThreadPool(30)
     val namespace = Namespace.of(IcebergMetadataWriter.MATANO_NAMESPACE)
 
     fun handle(event: RewriteManifestsRequest) {


### PR DESCRIPTION
- Currently we're using the synchronous IO from the Iceberg utils to read Parquet file footers for file metrics. This is very slow when processing many files (e.g. in redrive).
- Use Netty Async NIO with S3 to read file footers
- Tested to handle 1000 files in ~15 seconds in Lambda (not optimal but OK), happy case of few files as usual (~1s).
- (Includes minor change to make sure to drop view on Iceberg table delete)

Signed-off-by: 🐼 Samrose Ahmed 🐼 <samroseahmed@gmail.com>