### PR TITLE
🔧 support `key_pattern` in addition to key_prefix for ingest.s3_source configuration

### DIFF
--- a/infra/lib/data-batcher.ts
+++ b/infra/lib/data-batcher.ts
@@ -35,6 +35,7 @@ export class DataBatcher extends Construct {
       timeout: cdk.Duration.seconds(10),
       environment: {
         RUST_LOG: "warn,data_batcher=info",
+        MATANO_SOURCES_BUCKET: props.s3Bucket.bucket.bucketName,
         OUTPUT_QUEUE_URL: this.outputQueue.queueUrl,
       },
     });

--- a/infra/lib/log-source.ts
+++ b/infra/lib/log-source.ts
@@ -74,6 +74,7 @@ export interface LogSourceConfig {
     s3_source?: {
       bucket_name?: string;
       key_prefix?: string;
+      key_pattern?: string;
     };
     sqs_source?: {
       enabled?: boolean;

--- a/lib/rust/Cargo.lock
+++ b/lib/rust/Cargo.lock
@@ -2139,6 +2139,7 @@ dependencies = [
  "lambda_runtime",
  "lazy_static 1.4.0",
  "log",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml 0.9.10",
@@ -2824,9 +2825,9 @@ checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
 
 [[package]]
 name = "infer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6c16b11a665b26aeeb9b1d7f954cdeb034be38dd00adab4f2ae921a8fee804"
+checksum = "a898e4b7951673fce96614ce5751d13c40fc5674bc2d759288e46c3ab62598b3"
 dependencies = [
  "cfb",
 ]
@@ -3261,15 +3262,6 @@ dependencies = [
  "snafu",
  "vector_config",
  "vector_config_macros",
-]
-
-[[package]]
-name = "lru"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936d98d2ddd79c18641c6709e7bb09981449694e402d1a0f0f657ea8d61f4a51"
-dependencies = [
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -4674,7 +4666,7 @@ dependencies = [
  "futures-util",
  "lazy_static 1.4.0",
  "log",
- "lru 0.9.0",
+ "lru",
  "memmap2",
  "once_cell",
  "pest",
@@ -5309,11 +5301,12 @@ dependencies = [
  "lambda_runtime",
  "lazy_static 1.4.0",
  "log",
- "lru 0.8.0",
+ "lru",
  "once_cell",
  "pest",
  "pest_derive",
  "rayon",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml 0.9.10",

--- a/lib/rust/data_batcher/Cargo.toml
+++ b/lib/rust/data_batcher/Cargo.toml
@@ -14,6 +14,7 @@ serde = "^1"
 serde_json = "^1"
 serde_yaml = "0.9"
 log = "^0.4"
+regex = "1.5.4"
 tracing-subscriber = { version = "0.3.8", features = ["env-filter"] }
 tracing = { version = "0.1.30", features = ["log"] }
 lambda_runtime = "0.7.1"

--- a/lib/rust/shared/src/models.rs
+++ b/lib/rust/shared/src/models.rs
@@ -9,7 +9,6 @@ pub struct DataBatcherOutputRecord {
     pub key: String,
     pub size: i64,
     pub sequencer: String,
-    #[serde(skip)]
     pub log_source: String,
     #[serde(default)]
     pub retry_depth: Option<i64>,

--- a/lib/rust/transformer/Cargo.toml
+++ b/lib/rust/transformer/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.63.0"
 [dependencies]
 shared = { path = "../shared" }
 anymap = "0.12.1"
-lru = "0.8.0"
+lru = "0.9.0"
 tokio = { version = "1.17.0", features = ["macros"] }
 tokio-util = { version = "0.7", default-features = false, features = ["codec"] }
 rayon = "1.5.3"
@@ -20,7 +20,8 @@ async-compression = { version = "0.3.14", default-features = false, features = [
   "zstd",
   "stream",
 ] }
-infer = "0.11.0"
+infer = "0.12.0"
+regex = "1.5.4"
 arrow2 = { git = "https://github.com/jorgecarleitao/arrow2", features = [
   "io_avro",
   "io_avro_async",


### PR DESCRIPTION
See #90 

Sometimes your data across log sources is not written to a dedicate key prefix for each log source. To enable more advanced use cases, we now allow supplying a `key_pattern` which will be used to match the incoming object based on a known pattern (e.g. r'.*AWSLogs.*'). This can be used in combination with `key_prefix` which will be used for limiting the grant read policy on Matano's role if supplied. For example:

```yml
ingest:
  s3_source:
    bucket_name: my-s3-bucket
    key_prefix: AWSLogs
    key_pattern: AWSLogs/.*/CloudTrail # regex to match files written for AWS cloudtrail with a wildcard for account names
```