### PR TITLE
log_puller: Don't create secrets for sources that don't need them.

### DIFF
--- a/lib/rust/log_puller/src/main.rs
+++ b/lib/rust/log_puller/src/main.rs
@@ -126,14 +126,11 @@ async fn build_contexts() -> HashMap<String, PullLogsContext> {
                     .to_owned()
             });
 
-            let secret_arn = log_source_to_secret_arn_map
-                .get(&ls_name)
-                .context("Need secret arn.")
-                .unwrap();
+            let secret_arn = log_source_to_secret_arn_map.get(&ls_name);
 
             let ctx = PullLogsContext::new(
                 ls_name.to_owned(),
-                secret_arn.to_owned(),
+                secret_arn.cloned(),
                 log_source,
                 props,
                 tables_config,

--- a/lib/rust/log_puller/src/pullers/otx.rs
+++ b/lib/rust/log_puller/src/pullers/otx.rs
@@ -33,6 +33,10 @@ impl PullLogs for OtxPuller {
             .await?
             .context("Missing OTX API Key")?;
 
+        if api_key == "<placeholder>" {
+            return Ok(vec![]);
+        }
+
         let mut handles = vec![];
         let mut next_url: Option<String> = None;
         let mut is_first = true;

--- a/lib/rust/shared/src/sqs_util.rs
+++ b/lib/rust/shared/src/sqs_util.rs
@@ -65,7 +65,7 @@ pub fn sqs_errors_to_response(errors: Vec<SQSLambdaError>) -> Result<Option<SQSB
         let ids = errors
             .into_iter()
             .flat_map(|e| {
-                error!("Encountered error: {}", e);
+                error!("Encountered error: {:#}", e);
                 e.ids
             })
             .collect::<std::collections::HashSet<_>>()


### PR DESCRIPTION
Log sources like AbuseCH or AWS Inspector don't need secrets.

- Also minor fixes for skipping sources with no secrets yet.

