### PR TITLE
new nested aws config in matano.config.yml but support existing

### DIFF
--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import chalk from "chalk";
 import { Command, Flags, Errors } from "@oclif/core";
-import { isMatanoDirectory, readConfig } from "./util";
+import { isMatanoDirectory, parseMatanoConfig, readConfig } from "./util";
 import { CLIError } from "@oclif/core/lib/errors";
 import { execSync } from "child_process";
 
@@ -116,9 +116,9 @@ export default abstract class BaseCommand extends Command {
     if (awsAccountId && awsRegion) {
       return { awsAccountId, awsRegion };
     }
-    const matanoConfig = readConfig(userDirectory, "matano.config.yml");
-    if (!awsAccountId) awsAccountId = matanoConfig?.["aws_account"];
-    if (!awsRegion) awsRegion = matanoConfig?.["aws_region"];
+    const matanoConfig = parseMatanoConfig(userDirectory);
+    if (!awsAccountId) awsAccountId = matanoConfig?.aws?.account;
+    if (!awsRegion) awsRegion = matanoConfig?.aws?.region;
     if (!awsAccountId || !awsRegion) {
       this.error("AWS Account ID and/or AWS region not specified.", {
         suggestions: ["Specify AWS account/region in matano.config.yml"],

--- a/cli/src/commands/deploy.ts
+++ b/cli/src/commands/deploy.ts
@@ -9,7 +9,7 @@ import * as fse from "fs-extra";
 import path from "path";
 import * as YAML from "yaml";
 import { getCdkOutputDir, getCfnOutputsPath, getMatanoCdkApp, isPkg, getLocalProjRootDir } from "..";
-import { readConfig, safeLoadMatanoContext } from "../util";
+import { parseMatanoConfig, readConfig, safeLoadMatanoContext } from "../util";
 import BaseCommand from "../base";
 import { getCdkExecutable } from "..";
 
@@ -60,7 +60,7 @@ export default class Deploy extends BaseCommand {
       cdkArgs.push("--profile", awsProfile);
     }
 
-    const matanoConfig = readConfig(matanoUserDirectory, "matano.config.yml");
+    const matanoConfig = parseMatanoConfig(matanoUserDirectory);
     const matanoContext = safeLoadMatanoContext(matanoUserDirectory);
 
     const cdkContext: Record<string, any> = {

--- a/cli/src/commands/destroy.ts
+++ b/cli/src/commands/destroy.ts
@@ -7,7 +7,7 @@ import { Mode } from "aws-cdk/lib/api/plugin/credential-provider-source";
 import * as cxapi from "@aws-cdk/cx-api";
 import { CloudFormation } from "aws-sdk";
 import Table from "tty-table";
-import { promiseTimeout, readConfig, stackNameWithLabel } from "../util";
+import { parseMatanoConfig, promiseTimeout, readConfig, stackNameWithLabel } from "../util";
 import { waitForStackDelete } from "aws-cdk/lib/api/util/cloudformation";
 import * as AWS from "aws-sdk";
 
@@ -187,9 +187,7 @@ export default class Destroy extends BaseCommand {
         }
       } else {
         spinner.fail();
-        throw new Error(
-          `Failed deleting stack ${stackName} (current state: ${deletedStack?.stackStatus})`
-        );
+        throw new Error(`Failed deleting stack ${stackName} (current state: ${deletedStack?.stackStatus})`);
       }
     }
     spinner.succeed();
@@ -206,7 +204,7 @@ export default class Destroy extends BaseCommand {
       await sdkProvider.forEnvironment(cxapi.EnvironmentUtils.make(awsAccountId, awsRegion), Mode.ForReading, {})
     ).sdk.cloudFormation();
 
-    const matanoConfig = readConfig(matanoUserDirectory, "matano.config.yml");
+    const matanoConfig = parseMatanoConfig(matanoUserDirectory);
     const projectLabel = matanoConfig.project_label;
 
     const mainStackName = stackNameWithLabel("MatanoDPMainStack", projectLabel);
@@ -217,7 +215,7 @@ export default class Destroy extends BaseCommand {
       `Are you sure you want to delete the Matano stacks for account ${awsAccountId} and region ${awsRegion}? (y/n)`
     );
     if (!confirmed) {
-        return;
+      return;
     }
 
     await this.deleteIfExists(cfn, mainStackName);

--- a/cli/src/commands/generate/matano-dir.ts
+++ b/cli/src/commands/generate/matano-dir.ts
@@ -8,12 +8,13 @@ import ora from "ora";
 const autogenerateNote = ``;
 const sampleMatanoConfigYml = (awsAccountId?: string, awsRegion?: string) => `# Use this file for Matano configuration.
 
-aws_account: "${awsAccountId ?? "123456789012"}" # Specify the AWS account to deploy to.
-aws_region: "${awsRegion ?? "us-east-1"}" # Specify the AWS region to deploy to.
+aws:
+  account: "${awsAccountId ?? "123456789012"}" # Specify the AWS account to deploy to.
+  region: "${awsRegion ?? "us-east-1"}" # Specify the AWS region to deploy to.
 
-# Optionally, specify any tags to apply to the deployed resources.
-# aws_tags:
-#  key: "my_tag"
+  # Optionally, specify any tags to apply to the deployed resources.
+  # tags:
+  #   key: "my_tag"
 
 `;
 const sampleDetectionPy = `# ${autogenerateNote}

--- a/cli/src/commands/info.ts
+++ b/cli/src/commands/info.ts
@@ -7,7 +7,7 @@ import { Mode } from "aws-cdk/lib/api/plugin/credential-provider-source";
 import * as cxapi from "@aws-cdk/cx-api";
 import { CloudFormation } from "aws-sdk";
 import Table from "tty-table";
-import { promiseTimeout, readConfig, stackNameWithLabel, isInteractive } from "../util";
+import { promiseTimeout, readConfig, stackNameWithLabel, isInteractive, parseMatanoConfig } from "../util";
 
 export default class Info extends BaseCommand {
   static description = "Retrieves information about your Matano deployment in structured format.";
@@ -60,7 +60,7 @@ export default class Info extends BaseCommand {
       await sdkProvider.forEnvironment(cxapi.EnvironmentUtils.make(awsAccountId, awsRegion), Mode.ForReading, {})
     ).sdk.cloudFormation();
 
-    const matanoConfig = readConfig(matanoUserDirectory, "matano.config.yml");
+    const matanoConfig = parseMatanoConfig(matanoUserDirectory);
     const projectLabel = matanoConfig.project_label;
 
     const [o1, o2] = await Promise.all([

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -13,7 +13,7 @@ import RefreshContext from "./refresh-context";
 import { getCdkExecutable, getCdkOutputDir, getMatanoCdkApp, isPkg, getLocalProjRootDir } from "..";
 import GenerateMatanoDir from "./generate/matano-dir";
 import Deploy from "./deploy";
-import { AWS_REGIONS, fileExists, isInteractive, readConfig } from "../util";
+import { AWS_REGIONS, fileExists, isInteractive, parseMatanoConfig, readConfig } from "../util";
 import Info from "./info";
 
 const getAwsAcctId = async (profile?: string) => {
@@ -53,8 +53,9 @@ export default class Init extends BaseCommand {
     let resolvedArgs: any = {};
     if (flags["user-directory"]) {
       const matanoUserDirectory = path.resolve(flags["user-directory"]);
-      const config = readConfig(matanoUserDirectory, "matano.config.yml");
-      const { aws_account: awsAccountId, aws_region: awsRegion } = config;
+      const config = parseMatanoConfig(matanoUserDirectory);
+      const awsAccountId = config?.aws?.account;
+      const awsRegion = config?.aws?.region;
       resolvedArgs = {
         matanoUserDirectory,
         awsRegion,

--- a/cli/src/util.ts
+++ b/cli/src/util.ts
@@ -6,6 +6,21 @@ export function readConfig(directory: string, filename: string): Record<string, 
   return YAML.parse(fs.readFileSync(path.join(directory, filename), "utf8"));
 }
 
+export function parseMatanoConfig(matanoUserDirectory: string): Record<string, any> {
+  const config = readConfig(matanoUserDirectory, "matano.config.yml");
+
+  // Support legacy AWS config
+  if (!config.aws) {
+    config.aws = {
+      account: config.aws_account,
+      region: config.aws_region,
+      tags: config.aws_tags,
+    };
+  }
+
+  return config;
+}
+
 export function isMatanoDirectory(dirpath: string) {
   return fs.existsSync(dirpath) && fs.existsSync(path.join(dirpath, "matano.config.yml"));
 }

--- a/example/matano.config.yml
+++ b/example/matano.config.yml
@@ -1,7 +1,5 @@
-aws_account: "946413832404"
-aws_region: "us-east-1"
-aws_tags:
-  cost_center: "80432"
-
-vpc:
-  id: vpc-05175918865d89771 # vpc-0ea06dd2385eeb53c
+aws:
+  account: "123456789012"
+  region: "us-east-1"
+  tags:
+    cost_center: "80432"

--- a/infra/lib/MatanoStack.ts
+++ b/infra/lib/MatanoStack.ts
@@ -29,9 +29,11 @@ export function tagResources(scope: Construct, tags: (stack: cdk.Stack) => Recor
 }
 
 export interface MatanoConfiguration {
-  aws_account: string | undefined;
-  aws_region: string | undefined;
-  aws_tags: object | undefined;
+  aws: {
+    account: string;
+    region: string;
+    tags?: Record<string, string>;
+  };
   project_label: string | undefined;
   is_production: boolean | undefined;
   integrations?: Record<string, Record<string, any> | undefined>;
@@ -95,6 +97,6 @@ export class MatanoStack extends cdk.Stack {
   // }
 
   get userAwsTags(): object | undefined {
-    return this.matanoConfig.aws_tags;
+    return this.matanoConfig?.aws?.tags ?? this.matanoConfig?.aws_tags;
   }
 }


### PR DESCRIPTION
Change `matano.config.yml` to use config with `aws` object with nested keys instead of separate top level keys.

Continue to support existing aws_account, aws_region, aws_tags config (no breaking change)


from:

```yml
aws_account: "123456789012"
aws_region: "us-east-1"
aws_tags:
  key: "my_tag"
```
to:
```yml
aws:
  account: "123456789012"
  region: "us-east-1"
  tags:
    key: "my_tag"
```

will make it cleaner to add other configs.