### PR TITLE
Add a config option to not explicitly set S3 Block Public Access

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -109,6 +109,10 @@ export default class Init extends BaseCommand {
     if (awsProfile) {
       cdkArgs.push("--profile", awsProfile);
     }
+    const matanoConfig = parseMatanoConfig(matanoUserDirectory);
+    if (matanoConfig?.aws?.set_block_public_access === false) {
+      cdkArgs.push("--public-access-block-configuration", "false");
+    }
 
     const cdkContext: Record<string, any> = {
       matanoUserDirectory,

--- a/infra/lib/MatanoStack.ts
+++ b/infra/lib/MatanoStack.ts
@@ -7,6 +7,7 @@ import * as s3 from "aws-cdk-lib/aws-s3";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { FriendlyNamingAspect } from "./aspects/naming";
 import { RetentionPolicyAspect } from "./aspects/retention";
+import { S3BlockPublicAccessAspect } from "./aspects/s3-block-public-access";
 
 // from https://github.com/capralifecycle/liflig-cdk/blob/master/src/tags.ts
 export function tagResources(scope: Construct, tags: (stack: cdk.Stack) => Record<string, string>): void {
@@ -33,6 +34,7 @@ export interface MatanoConfiguration {
     account: string;
     region: string;
     tags?: Record<string, string>;
+    set_block_public_access?: boolean;
   };
   project_label: string | undefined;
   is_production: boolean | undefined;
@@ -72,6 +74,7 @@ export class MatanoStack extends cdk.Stack {
 
     cdk.Aspects.of(this).add(new FriendlyNamingAspect());
     cdk.Aspects.of(this).add(new RetentionPolicyAspect());
+    cdk.Aspects.of(this).add(new S3BlockPublicAccessAspect());
   }
 
   humanCfnOutput(name: string, props: cdk.CfnOutputProps) {

--- a/infra/lib/aspects/s3-block-public-access.ts
+++ b/infra/lib/aspects/s3-block-public-access.ts
@@ -1,0 +1,21 @@
+import { IConstruct } from "constructs";
+import * as cdk from "aws-cdk-lib";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import { MatanoStack } from "../MatanoStack";
+
+export class S3BlockPublicAccessAspect implements cdk.IAspect {
+  public visit(node: IConstruct): void {
+    const doSetBlockPublicAccess = (cdk.Stack.of(node) as MatanoStack).matanoConfig?.aws?.set_block_public_access !== false;
+
+    if (node instanceof s3.CfnBucket) {
+      if (node.publicAccessBlockConfiguration === undefined && doSetBlockPublicAccess) {
+        node.publicAccessBlockConfiguration = {
+          blockPublicAcls: true,
+          blockPublicPolicy: true,
+          ignorePublicAcls: true,
+          restrictPublicBuckets: true,
+        }
+      }
+    }
+  }
+}

--- a/infra/lib/enrichment.ts
+++ b/infra/lib/enrichment.ts
@@ -149,7 +149,6 @@ export class Enrichment extends Construct {
     this.enrichmentConfigs = this.loadEnrichmentTables();
 
     this.enrichmentTablesBucket = new s3.Bucket(this, "EnrichmentTables", {
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       lifecycleRules: [
         {
           prefix: "temp-enrich-sync",

--- a/infra/lib/s3-bucket-notifs.ts
+++ b/infra/lib/s3-bucket-notifs.ts
@@ -24,7 +24,6 @@ export class S3BucketWithNotifications extends Construct {
 
     this.bucket = new s3.Bucket(this, "Bucket", {
       ...props.bucketProps,
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
     });
 
     const bucketName = props?.bucketProps?.bucketName;

--- a/infra/src/DPCommonStack.ts
+++ b/infra/src/DPCommonStack.ts
@@ -28,9 +28,6 @@ export class DPCommonStack extends MatanoStack {
     super(scope, id, props);
 
     this.matanoIngestionBucket = new S3BucketWithNotifications(this, "MatanoIngestionBucket", {
-      bucketProps: {
-        blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
-      },
     });
 
     // For delivering Cloudtrail, S3 access logs
@@ -55,9 +52,6 @@ export class DPCommonStack extends MatanoStack {
     });
 
     this.matanoLakeStorageBucket = new S3BucketWithNotifications(this, "MatanoLakeStorageBucket", {
-      bucketProps: {
-        blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
-      },
       queueProps: {
         visibilityTimeout: cdk.Duration.seconds(185),
       },
@@ -65,7 +59,6 @@ export class DPCommonStack extends MatanoStack {
     });
 
     this.realtimeBucket = new Bucket(this, "MatanoRealtimeBucket", {
-      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
       lifecycleRules: [{ expiration: cdk.Duration.days(7) }],
     });
     this.realtimeBucketTopic = new Topic(this, "MatanoRealtimeBucketNotifications", {
@@ -91,7 +84,6 @@ export class DPCommonStack extends MatanoStack {
     });
 
     this.matanoAthenaResultsBucket = new s3.Bucket(this, "MatanoAthenaResults", {
-      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
       lifecycleRules: [{ expiration: cdk.Duration.days(60) }],
     });
     const matanoDefaultAthenaWorkgroup = new athena.CfnWorkGroup(this, "MatanoDefault", {


### PR DESCRIPTION
Unblocks users who have org policies preventing usage of s3:PutPublicAccessBlock API (#124).

#### Usage

Set `aws.set_block_public_access` as `false` in `matano.config.yml`:

```yml
# matano.config.yml

aws:
  account: "123456789012"
  region: "us-east-1"
  set_block_public_access: false
```