### PR TITLE
fix: detection: dont error in alerting in case no event field

### DIFF
--- a/lib/python/matano_detection/detection/common.py
+++ b/lib/python/matano_detection/detection/common.py
@@ -310,7 +310,7 @@ def create_alert(alert_response):
         **{k: v for k, v in record.items() if k in ALERT_ECS_FIELDS},
         "ts": time.time(),
         "event": {
-            **record.get("event", {}),
+            **(record.get("event") or {}),
             "kind": "signal",
         },
         "matano": {


### PR DESCRIPTION
Right now, error occurs in create_alert when there is no event ECS field, this fixes the logic to guard against.