### PR TITLE
minor: Emit some more logs

### DIFF
--- a/lib/rust/alert_forwarder/src/main.rs
+++ b/lib/rust/alert_forwarder/src/main.rs
@@ -179,6 +179,7 @@ async fn handler(event: LambdaEvent<SqsEvent>) -> Result<()> {
     });
 
     let log = json!({
+        "matano_log": true,
         "type": "matano_service_log",
         "service": "alert_forwarder",
         "alert_id": alert_id,

--- a/lib/rust/alert_writer/src/main.rs
+++ b/lib/rust/alert_writer/src/main.rs
@@ -332,6 +332,7 @@ async fn handler(event: LambdaEvent<SqsEvent>) -> Result<()> {
     }
 
     let log = json!({
+        "matano_log": true,
         "type": "matano_service_log",
         "service": "alert_writer",
         "processed_alert_ids": processed_alert_ids,


### PR DESCRIPTION
wip observability

Modifies several components to emit logs. Prep for future work and enables basic search for now in e.g. CloudWatch Logs insights.

```sql
filter matano_log = 1
# | filter type="matano_service_log" # matano_table_log
| sort @timestamp asc
```