### PR TITLE
fix:  adds lookup_keys for cisa_kev enrichment table

### DIFF
--- a/data/managed/enrichment/cisa_kev/enrichment.yml
+++ b/data/managed/enrichment/cisa_kev/enrichment.yml
@@ -39,3 +39,5 @@ schema:
             type: string
           - name: notes
             type: string
+lookup_keys:
+  - vulnerability.id


### PR DESCRIPTION
Based on https://www.matano.dev/docs/enrichment/lookup-data - it looks like `lookup_keys` needs to be specified in order to be able to lookup against the enrichment table in our python rules and VRL. Adding this to the managed enrichment definition for `cisa_kev`