### PR TITLE
Fix: Prevent confusing error when invalid detection deployed

### DIFF
--- a/lib/python/matano_detection/detection/common.py
+++ b/lib/python/matano_detection/detection/common.py
@@ -145,6 +145,7 @@ def handler(event, context):
 
     if DETECTION_CONFIGS is None:
         _load_detection_configs()
+    if TABLE_DETECTION_CONFIG is None:
         _load_table_detection_config()
 
     alert_responses = []


### PR DESCRIPTION
Currently if loading module fails after detection configuration is loaded, the error is confusing. Fix here