### PR TITLE
pin AVRO version in transformer to keep using rust 1.64 (due to cargo-lambda / GH build setup)

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.63
+          override: true
+          default: true
     
       # Use rust-cache to cache dependencies, which is a large chunk of the build.
       - name: Cache Rust

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -23,7 +23,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.63
-
+          override: true
+          default: true
       # Use rust-cache to cache dependencies, which is a large chunk of the build.
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/infra/lib/iceberg-maintenance.ts
+++ b/infra/lib/iceberg-maintenance.ts
@@ -291,7 +291,7 @@ class IcebergExpireSnapshots extends Construct {
 
     const smScheduleRule = new events.Rule(this, "Rule", {
       description: "[Matano] Schedules the Iceberg expire snapshots workflow.",
-      schedule: events.Schedule.rate(cdk.Duration.days(1)),
+      schedule: events.Schedule.rate(cdk.Duration.hours(1)),
     });
 
     smScheduleRule.addTarget(
@@ -388,7 +388,7 @@ export class IcebergMaintenance extends Construct {
       lakeStorageBucket: props.lakeStorageBucket,
     });
 
-    new IcebergAthenaExpireSnapshots(this, "ExpireSnapshotsAthena", {
+    new IcebergExpireSnapshots(this, "ExpireSnapshotsAthena", {
       tableNames,
       lakeStorageBucket: props.lakeStorageBucket,
     });

--- a/lib/rust/transformer/Cargo.toml
+++ b/lib/rust/transformer/Cargo.toml
@@ -32,7 +32,7 @@ arrow2 = { git = "https://github.com/jorgecarleitao/arrow2", features = [
   "io_json",
 ] }
 indexmap = "1.9.1"
-apache-avro = { git = "https://github.com/apache/avro.git", features = [
+apache-avro = { git = "https://github.com/apache/avro.git", rev = "05099c3", features = [
   "zstandard",
   "snappy",
 ] }


### PR DESCRIPTION
current nightly release broken due to this issue, fix