### PR TITLE
Remove bracket in VRL to fix o365 log ingest

### DIFF
--- a/data/managed/log_sources/o365/tables/audit.yml
+++ b/data/managed/log_sources/o365/tables/audit.yml
@@ -260,7 +260,7 @@ transform: |-
     .event.category = push(.event.category, "authentication")
     .event.type = push(.event.type, "start") 
     .event.type = push(.event.type, "access") 
-  } else if .event.code == "SharePointFileOperation" || .event.code == "SharePointSharingOperation" { { 
+  } else if .event.code == "SharePointFileOperation" || .event.code == "SharePointSharingOperation" {  
     .url.original = del(.o365.audit.ObjectId)
     .file.directory = del(.o365.audit.SourceRelativeUrl)
     .file.name = del(.o365.audit.SourceFileName)


### PR DESCRIPTION
Removing a bracket in the VRL to allow for ingestion of O365 logs.

This contribution is made by Claire Casalnova as an employee of the Cybersecurity and Infrastructure Security Agency (CISA), a subdivision of the Department of Homeland Security (DHS) and is considered a government work under 17 USC 105. United States copyright is not asserted. International rights are reserved consistent with the license of this package. For questions about this contribution, please contact the author or licensing@cisa.dhs.gov.
