### PR TITLE
Update system workgroup to Athena Engine Version 3

### DIFF
--- a/infra/src/DPCommonStack.ts
+++ b/infra/src/DPCommonStack.ts
@@ -124,7 +124,7 @@ export class DPCommonStack extends MatanoStack {
       description: "[Matano] Matano System Athena Work Group. Used for system queries such as table maintenance.",
       workGroupConfiguration: {
         engineVersion: {
-          selectedEngineVersion: "Athena engine version 2",
+          selectedEngineVersion: "Athena engine version 3",
         },
         publishCloudWatchMetricsEnabled: true,
         resultConfiguration: {


### PR DESCRIPTION
Athena Engine Version 2 is being deprecated, and isn't necessary due to the timestamp precision workaround.