### PR TITLE
Fix decode_percent with fallible assertion cloudflare managed

### DIFF
--- a/data/managed/log_sources/cloudflare/tables/http_request.yml
+++ b/data/managed/log_sources/cloudflare/tables/http_request.yml
@@ -496,7 +496,7 @@ transform: |
   if err == null {
       .url = parsed
       if .url.query != null {
-        .url.query = decode_percent!(split!(.json.ClientRequestReferer, "?")[1])
+        .url.query = decode_percent(split!(.json.ClientRequestReferer, "?")[1]) ?? null
       }
       .url.domain = del(.url.host)
   }                                                                         


### PR DESCRIPTION
decode_percent!() has been resulting in errors when null is encountered. This fix will allow it to not error out when nulls are encountered.

This fix is for Cloudflare managed source on the http_requests table